### PR TITLE
getting the beginning of inline program GRPC communication set up

### DIFF
--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -149,6 +149,7 @@ Pulumi.X.Automation.XStack.RemoveConfigAsync(System.Collections.Generic.IEnumera
 Pulumi.X.Automation.XStack.RemoveConfigValueAsync(string key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 Pulumi.X.Automation.XStack.SetConfigAsync(System.Collections.Generic.IDictionary<string, Pulumi.X.Automation.ConfigValue> configMap, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 Pulumi.X.Automation.XStack.SetConfigValueAsync(string key, Pulumi.X.Automation.ConfigValue value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
+Pulumi.X.Automation.XStack.Up(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 Pulumi.X.Automation.XStack.Workspace.get -> Pulumi.X.Automation.Workspace
 abstract Pulumi.X.Automation.Workspace.CreateStackAsync(string stackName, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task
 abstract Pulumi.X.Automation.Workspace.EnvironmentVariables.get -> System.Collections.Generic.IDictionary<string, string>

--- a/sdk/dotnet/Pulumi/Pulumi.csproj
+++ b/sdk/dotnet/Pulumi/Pulumi.csproj
@@ -26,6 +26,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.6">
       <PrivateAssets>all</PrivateAssets>
@@ -39,6 +43,7 @@
 
     <PackageReference Include="Google.Protobuf" Version="3.10.0" />
     <PackageReference Include="Grpc" Version="2.24.0" />
+    <PackageReference Include="Grpc.AspNetCore" Version="2.24.0" />
     <PackageReference Include="Grpc.Tools" Version="2.24.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/sdk/dotnet/Pulumi/X/Automation/LanguageRuntimeService.cs
+++ b/sdk/dotnet/Pulumi/X/Automation/LanguageRuntimeService.cs
@@ -9,7 +9,7 @@ using Pulumirpc;
 
 namespace Pulumi.X.Automation
 {
-    internal class Server : LanguageRuntime.LanguageRuntimeBase, IDisposable
+    internal class LanguageRuntimeService : LanguageRuntime.LanguageRuntimeBase, IDisposable
     {
         // MaxRpcMesageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
         public const int MaxRpcMesageSize = 1024 * 1024 * 400;
@@ -21,7 +21,7 @@ namespace Pulumi.X.Automation
         private readonly PulumiFn _program;
         private bool _isDisposed;
 
-        public Server(PulumiFn program)
+        public LanguageRuntimeService(PulumiFn program)
         {
             _program = program;
         }


### PR DESCRIPTION
The beginnings of the XStack.Up method, mostly following the pattern set in the typescript implementation. Most of the implementation is missing here - I just added the bits necessary for spinning up a GRPC server to run the inline program if specified.

The FrameworkReference addition is a heavy one but I don't know of any way to avoid that.

For obtaining the port for a dynamically bound server I followed this article: https://andrewlock.net/how-to-automatically-choose-a-free-port-in-asp-net-core/


The main unknown I have left a TODO note on is the HTTPS settings on kestrel. I ran this sample code on a separate project and it worked fine for me, but I know that `UseHttps()` method uses the default certificate installed on the machine - and the dotnet SDK comes with its own self-signed cert. We might have to jump through a few extra hoops of generating a single use cert or something like that. I have not looked, but I imagine that is basically what the typescript implementation is doing with `grpc.ServerCredentials.createInsecure()`